### PR TITLE
Remove autoconfig warning

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,6 +2,7 @@ c.tabs.show = 'never'
 c.tabs.tabs_are_windows = True
 c.window.title_format = '{private}{perc}{current_title}'
 
+config.load_autoconfig()
 config.bind('q', 'spawn --userscript tab-close')
 config.bind('u', 'undo --window')
 config.bind(']', 'spawn ~/.local/share/i3/window-tool tab-focus next')


### PR DESCRIPTION
I added a line in order to remove the warning and load settings that have already been set from inside the GUI. You may want to add a `False` parameter in case you prefer the reverse behavior as a default.